### PR TITLE
Do not ignore pause requests if not playing

### DIFF
--- a/src/com/videojs/providers/HTTPVideoProvider.as
+++ b/src/com/videojs/providers/HTTPVideoProvider.as
@@ -248,8 +248,9 @@ package com.videojs.providers{
         }
         
         public function pause():void{
+            _ns.pause();
+
             if(_isPlaying && !_isPaused){
-                _ns.pause();
                 _isPaused = true;
                 _model.broadcastEventExternally(ExternalEventName.ON_PAUSE);
                 if(_isBuffering){
@@ -484,7 +485,7 @@ package com.videojs.providers{
                     break;
                 
                 case "NetStream.Play.Stop":
-                    
+
                     if(!_loop){
                         _isPlaying = false;
                         _isPaused = true;


### PR DESCRIPTION
If `play` was called on the NetStream but playback had not actually begun, calling `pause` on the HTTPVideoProvider was silently ignored. Instead, always pause the NetStream, which shouldn't be harmful if the video is already paused. The additional mutation performed by this method was left unaltered.
