### PR TITLE
Update networkState() and loadstart event to be more like HTML5 spec

### DIFF
--- a/src/com/videojs/VideoJSModel.as
+++ b/src/com/videojs/VideoJSModel.as
@@ -548,7 +548,7 @@ package com.videojs{
             // We need to determine which provider to load, based on the values of our exposed properties.
             switch(_mode){
                 case PlayerMode.VIDEO:
-                    
+                    broadcastEventExternally(ExternalEventName.ON_LOAD_START);
                     if(_currentPlaybackType == PlaybackType.HTTP){
                         __src = {
                             path: _src
@@ -569,6 +569,7 @@ package com.videojs{
                     
                     break;
                 case PlayerMode.AUDIO:
+                    broadcastEventExternally(ExternalEventName.ON_LOAD_START);
                     __src = {
                         path:_src
                     };

--- a/src/com/videojs/providers/HTTPAudioProvider.as
+++ b/src/com/videojs/providers/HTTPAudioProvider.as
@@ -222,7 +222,6 @@ package com.videojs.providers{
                 catch(e:Error){
                     _model.broadcastErrorEventExternally("audioloaderror");
                 }
-                _model.broadcastEventExternally(ExternalEventName.ON_LOAD_START);
                 _model.broadcastEventExternally(ExternalEventName.ON_BUFFER_EMPTY);
             }
         }
@@ -280,7 +279,6 @@ package com.videojs.providers{
                     }
                     _soundChannel = _sound.play();
                     _soundChannel.addEventListener(Event.SOUND_COMPLETE, onSoundPlayComplete);
-                    _model.broadcastEventExternally(ExternalEventName.ON_LOAD_START);
                     _model.broadcastEventExternally(ExternalEventName.ON_BUFFER_EMPTY);    
                 }
             }

--- a/src/com/videojs/providers/HTTPVideoProvider.as
+++ b/src/com/videojs/providers/HTTPVideoProvider.as
@@ -452,7 +452,6 @@ package com.videojs.providers{
                     _loadStartTimestamp = getTimer();
                     _throughputTimer.reset();
                     _throughputTimer.start();
-                    _model.broadcastEventExternally(ExternalEventName.ON_LOAD_START);
                     _model.broadcastEventExternally(ExternalEventName.ON_BUFFER_EMPTY);
                     if(_pauseOnStart && _loadStarted == false){
                         _ns.pause();

--- a/src/com/videojs/providers/HTTPVideoProvider.as
+++ b/src/com/videojs/providers/HTTPVideoProvider.as
@@ -124,7 +124,10 @@ package com.videojs.providers{
         
         public function get networkState():int{
             if(!_loadStarted){
-                return 0;
+                // returning NETWORK_LOADING because the provider won't be
+                // loaded unless a source has already been selected.
+                // In html5 sense this means the network is not NETWORK_EMPTY
+                return 2;
             }
             else{
                 if(_loadCompleted){

--- a/src/com/videojs/providers/RTMPVideoProvider.as
+++ b/src/com/videojs/providers/RTMPVideoProvider.as
@@ -119,7 +119,7 @@ package com.videojs.providers{
         
         public function get networkState():int{
             if(!_loadStarted){
-                return 0;
+                return 2;
             }
             else{
                 if(_loadCompleted){

--- a/src/com/videojs/providers/RTMPVideoProvider.as
+++ b/src/com/videojs/providers/RTMPVideoProvider.as
@@ -413,7 +413,6 @@ package com.videojs.providers{
             _ns.bufferTime = 1;
             _ns.play(_src.streamURL);
             _videoReference.attachNetStream(_ns);
-            _model.broadcastEventExternally(ExternalEventName.ON_LOAD_START);
             _model.broadcastEvent(new VideoPlaybackEvent(VideoPlaybackEvent.ON_STREAM_READY, {ns:_ns}));
         }
         


### PR DESCRIPTION
networkState was returning 0 even after a source was selected, which isn't right per spec.

The loadstart event wasn't triggering until play() was called. Also not right. It should be triggered after it's determined that there are sources to choose from (either src="" or <source>)