### PR TITLE
Use netstream methods to determine the amount buffered

### DIFF
--- a/src/com/videojs/providers/HTTPVideoProvider.as
+++ b/src/com/videojs/providers/HTTPVideoProvider.as
@@ -148,7 +148,7 @@ package com.videojs.providers{
                 return (_ns.bytesLoaded / _ns.bytesTotal) * duration;
             }
             else{
-                return 0;
+                return _ns.bufferLength + _ns.time;
             }
         }
         


### PR DESCRIPTION
When duration is not available, use bufferLength and time on the netstream object to determine the endpoint of the buffered time range.

@heff: `bufferLength` and `time` are supported in Flash 9+. I think it might be a good idea to drop the positive branch of this conditional entirely. Thoughts?
