### PR TITLE
Buffered may be called before the NetStream is ready

### DIFF
--- a/src/com/videojs/providers/HTTPVideoProvider.as
+++ b/src/com/videojs/providers/HTTPVideoProvider.as
@@ -147,8 +147,10 @@ package com.videojs.providers{
             if(duration > 0){
                 return (_ns.bytesLoaded / _ns.bytesTotal) * duration;
             }
-            else{
+            else if (_ns){
                 return _ns.bufferLength + _ns.time;
+            } else{
+                 return 0;
             }
         }
         


### PR DESCRIPTION
PR #66 introduced an issue when the NetStream was not available at the time that buffered time ranges were requested from the HTTPVideoProvider. This would cause calls from JS to throw exceptions that didn't interrupt playback but made the console look terrible. Now, check whether the netstream has been set before trying to figure out the current buffered time. If the netstream isn't available, just return 0.
