### PR TITLE
Added onBWCheck method for the RTMP streaming

### DIFF
--- a/src/com/videojs/providers/RTMPVideoProvider.as
+++ b/src/com/videojs/providers/RTMPVideoProvider.as
@@ -605,6 +605,13 @@ package com.videojs.providers{
         }
         
         /**
+         * Called from FMS during bandwidth detection
+         */
+        public function onBWCheck(... pRest):Number {
+            return 0;
+        }
+        
+        /**
          * Called from FMS when bandwidth detection is completed.
          */
         public function onBWDone(... pRest):void {        


### PR DESCRIPTION
I got an ActionScript error when rtmp streaming was started in debugging.

```
Error #2044: Unhandled AsyncErrorEvent : 
text=Error #2095: flash.net.NetConnection was unable to invoke callback onBWCheck
error=ReferenceError: Error #1069: Property onBWCheck not found on flash.net.NetConnection and there is no default value.
    at com.videojs.providers::RTMPVideoProvider/initNetConnection()
    at com.videojs.providers::RTMPVideoProvider/play()
    at com.videojs::VideoJSModel/play()
    at VideoJS/onPlayCalled()
    at Function/http://adobe.com/AS3/2006/builtin::apply()
    at flash.external::ExternalInterface$/_callIn()
    at Function/<anonymous>()
```

According to the developers guide, it requires to be implemented.
http://help.adobe.com/en_US/FlashMediaServer/3.5_Deving/WS5b3ccc516d4fbf351e63e3d11a0773d56e-7ffa.html
