### PR TITLE
Fixed to be able to replay when the RTMP streaming is ended

### DIFF
--- a/src/com/videojs/providers/RTMPVideoProvider.as
+++ b/src/com/videojs/providers/RTMPVideoProvider.as
@@ -252,7 +252,9 @@ package com.videojs.providers{
             }
             // video playback ended, seek to beginning
             else if(_hasEnded){
+                _ns.pause();
                 _ns.seek(0);
+                _ns.resume();
                 _isPlaying = true;
                 _isPaused = false;
                 _hasEnded = false;
@@ -521,6 +523,7 @@ package com.videojs.providers{
                     // playback is over
                     if (_hasEnded) {
                         if(!_loop){
+                            pause();
                             _isPlaying = false;
                             _hasEnded = true;
                             _reportEnded = true;
@@ -528,7 +531,9 @@ package com.videojs.providers{
                             _model.broadcastEventExternally(ExternalEventName.ON_PLAYBACK_COMPLETE);
                         }
                         else{
+                            _ns.pause();
                             _ns.seek(0);
+                            _ns.resume();
                         }
                     }
                     // other stream buffering


### PR DESCRIPTION
The video-js-swf doesn't stop (pause) when a video is ended. Then, it doesn't replay with 1 click. Our streaming server is Red5 with RTMP streaming.

According to the developers guide (Controlling video playback), the pause action is needed before seeking and call resume() to play after paused.
http://help.adobe.com/en_US/as3/dev/WS5b3ccc516d4fbf351e63e3d118a9b90204-7d4d.html

``` as
function stopHandler(event:MouseEvent):void 
{ 
    // Pause the stream and move the playhead back to 
    // the beginning of the stream. 
    ns.pause(); 
    ns.seek(0); 
} 
```

Reference: http://help.adobe.com/en_US/FlashPlatform/reference/actionscript/3/flash/net/NetStream.html

I think that calling 3 methods(pause, seek, resume) at the same time is better since it's difficult to understand which method is called in order on event-driven processing. 

This patch works for us with video-js-4.3.0. Could you review it?
