### PR TITLE
The progress is over the duration time dragging the end point of progress with RTMP streaming

### DIFF
--- a/src/com/videojs/providers/RTMPVideoProvider.as
+++ b/src/com/videojs/providers/RTMPVideoProvider.as
@@ -69,7 +69,12 @@ package com.videojs.providers{
         
         public function get time():Number{
             if(_ns != null){
-                return _ns.time;
+                if (_model.duration != 0 && _ns.time > _model.duration){
+                    return _model.duration;
+                }
+                else{
+                    return _ns.time;
+                }
             }
             else{
                 return 0;
@@ -243,7 +248,7 @@ package com.videojs.providers{
                 initNetConnection();
             }
             // if the asset is paused
-            else if(_isPaused && !_reportEnded){
+            else if(_isPaused && !_reportEnded && _model.time < _model.duration){
                 _pausePending = false;
                 _ns.resume();
                 _isPaused = false;
@@ -251,7 +256,7 @@ package com.videojs.providers{
                 _model.broadcastEvent(new VideoPlaybackEvent(VideoPlaybackEvent.ON_STREAM_START, {}));
             }
             // video playback ended, seek to beginning
-            else if(_hasEnded){
+            else if(_hasEnded || _model.time == _model.duration){
                 _ns.pause();
                 _ns.seek(0);
                 _ns.resume();

--- a/src/com/videojs/providers/RTMPVideoProvider.as
+++ b/src/com/videojs/providers/RTMPVideoProvider.as
@@ -252,7 +252,9 @@ package com.videojs.providers{
             }
             // video playback ended, seek to beginning
             else if(_hasEnded){
+                _ns.pause();
                 _ns.seek(0);
+                _ns.resume();
                 _isPlaying = true;
                 _isPaused = false;
                 _hasEnded = false;
@@ -521,6 +523,7 @@ package com.videojs.providers{
                     // playback is over
                     if (_hasEnded) {
                         if(!_loop){
+                            pause();
                             _isPlaying = false;
                             _hasEnded = true;
                             _reportEnded = true;
@@ -528,7 +531,9 @@ package com.videojs.providers{
                             _model.broadcastEventExternally(ExternalEventName.ON_PLAYBACK_COMPLETE);
                         }
                         else{
+                            _ns.pause();
                             _ns.seek(0);
+                            _ns.resume();
                         }
                     }
                     // other stream buffering


### PR DESCRIPTION
I got the strange phenomenon with RTMP streaming using Red5 server.
This patch is including videojs/video-js-swf#77.
### Description:

Happens on Windows 7 and Ubuntu 12.04LTS.
Seen with IE8, IE9, Firefox 26 Ubuntu,  Chrome32 Ubuntu, Flash 11.2.
1. play streaming with RTMP
2. drag the mouse point the end point of progress or right side of the player
3. the progress is over the duration

I don't know why, but NetStream.time returns milliseconds instead of seconds when I did above according to my debugging.

Reference: 
http://help.adobe.com/en_US/FlashPlatform/reference/actionscript/3/flash/net/NetStream.html#time
### Expected:

The progress is the same as long as the duration.
### Acutual:

The progress is over the duration like this.

![progress_over_duration1](https://f.cloud.github.com/assets/96569/2117529/856e5a26-90d4-11e3-8cb3-ad0ee65caa2a.png)
