### PR TITLE
Fixes for initial setup and for packaging up less files

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,2 +1,3 @@
-# .npmignore needed so dist dir won't be ignored
-# https://npmjs.org/doc/developers.html#Keeping-files-out-of-your-package
+# Exclude everything but the contents of the dist directory.
+**/*
+!dist/**

--- a/README.md
+++ b/README.md
@@ -6,48 +6,34 @@ Installation
 ============
 
 1. Install Node Packages.
-
 ```bash
     npm install
    ```
-
 2. Compile SWF.
-
 Development (places new SWF in /dist/):
-
 ```bash
     grunt mxmlc
    ```
-
 Production/ Distribution (runs mxmlc task and copies SWF to dist/):
-
 ```bash
     grunt dist
    ```
-
 3. Run Connect Server.
-
 ```bash
     grunt connect:dev
 ```
-
-8. Open your browser at [http://localhost:8000/index.html](http://localhost:8000/index.html) to see a video play.  You can keep using grunt to rebuild the Flash code.
+4. Open your browser at [http://localhost:8000/index.html](http://localhost:8000/index.html) to see a video play.  You can keep using grunt to rebuild the Flash code.
 
 
 Running Unit and Integration Tests
 ===========
 
-** Notes - We should drop all of this for grunt based / Karma testing.
+** Note - We want to drop all of this for grunt based / Karma testing.
 
 For unit tests, this project uses [FlexUnit](http://flexunit.org/). The unit tests can be found in [project root]/src/com/videojs/test/
 
 For integration tests, this project uses [qunit](http://qunitjs.com/). The integration tests can be found in [project root]/test
 
-In order to run all of the tests, run test.sh.
-
-    ./test.sh
-
-A copy of the SWF produced for the unit tests will be compiled into the bin-debug folder.  Both the unit and integration tests will attempt to run with the 'open' command, or an instruction will be given on how to run them manually.
+In order to run all of the tests, use the links at  [http://localhost:8000/index.html](http://localhost:8000/index.html)
 
 There are very few tests.  Adding to them is a fantastic and much appreciated way to contribute.
-

--- a/index.html
+++ b/index.html
@@ -1,3 +1,3 @@
-<a href="tests/test.html">Automated Tests</a><br>
 <a href="tests/manual/index.html">Manual Tests</a><br>
-<a href="sandbox/">Sandbox (all files in this directory will be ignored)</a><br>
+<a href="tests/test.html">Automated Tests (needs some work to use without local changes)</a><br> 
+<a href="sandbox/">Sandbox (all files in this directory will be ignored)</a> <br>

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   },
   "devDependencies": {
     "async": "~0.2.9",
-    "flex-sdk": "4.6.0",
+    "flex-sdk": "4.6.0-0",
     "video.js": "4.3.0",
     "grunt-cli": "~0.1.0",
     "grunt": "~0.4.0",


### PR DESCRIPTION
I wanted to make sure we had less files packaged up with npm pack here, as there's a huge number of files that were being included here that weren't needed.  I ended up making a few extra changes as I tried the README that I haven't looked at in a long time.  Changes include:
1. Change npmignore so that only README and dist/video-js.swf are included
2. Remove extra lines in README so that there's an ordered list instead of "1." many times
3. Change testing section in README to reflect what's really there now
4. Change index.html to indicate that the automated tests aren't working from the given link right now
5. Update package.json's flex-sdk version to something that works.  This is the number on npmjs.org, while the version that was in there was giving a 404

The two things I didn't fix that I saw were that the automated tests don't work out of the box, looks like some files that were used/copied before aren't there anymore.  I just put a note on that.  The second thing is that I didn't get the "Sandbox" link in index.html, which just seemed to be a blank page for me.
