### PR TITLE
Add getter/setter for Netstream.bufferTime to control buffering

### DIFF
--- a/src/VideoJS.as
+++ b/src/VideoJS.as
@@ -258,6 +258,9 @@ package{
                 case "readyState":
                     return _app.model.readyState;
                     break;
+                case "bufferTime":
+                    return _app.model.bufferTime;
+                    break;
                 case "buffered":
                     return _app.model.buffered;
                     break;
@@ -334,6 +337,9 @@ package{
                     break;
                 case "rtmpStream":
                     _app.model.rtmpStream = String(pValue);
+                    break;
+                case "bufferTime":
+                    _app.model.bufferTime = Number(pValue);
                     break;
                 default:
                     _app.model.broadcastErrorEventExternally(ExternalErrorEventName.PROPERTY_NOT_FOUND, pPropertyName);

--- a/src/com/videojs/VideoJSModel.as
+++ b/src/com/videojs/VideoJSModel.as
@@ -358,6 +358,18 @@ package com.videojs{
             }
             return 0;
         }
+
+        public function get bufferTime():Number{
+            if(_provider){
+                return _provider.bufferTime;
+            }
+            return 0;
+        }
+        public function set bufferTime(pBufferTime:Number):void {
+            if(_provider){
+                _provider.bufferTime = pBufferTime;
+            }
+        }
         
         /**
          * Returns the total size of the current video, in bytes.

--- a/src/com/videojs/providers/HTTPAudioProvider.as
+++ b/src/com/videojs/providers/HTTPAudioProvider.as
@@ -123,6 +123,14 @@ package com.videojs.providers{
             throw "HTTPAudioProvider does not support abort";
         }
         
+        public function get bufferTime():Number{
+            throw "HTTPAudioProvider does not support bufferTime";
+        }
+
+        public function set bufferTime(pBufferTime:Number):void{
+            throw "HTTPAudioProvider does not support bufferTime";
+        }
+
         public function get buffered():Number{
             if(duration > 0){
                 return (bytesLoaded / bytesTotal) * duration;

--- a/src/com/videojs/providers/HTTPVideoProvider.as
+++ b/src/com/videojs/providers/HTTPVideoProvider.as
@@ -200,6 +200,17 @@ package com.videojs.providers{
             }
         }
         
+        public function get bufferTime():Number{
+            return _ns.bufferTime;
+        }
+
+        public function set bufferTime(pBufferTime:Number):void{
+            if(pBufferTime <= 0){
+                _ns.bufferTime = 0;
+            } else {
+                _ns.bufferTime = pBufferTime;
+            }
+        }
         public function get bytesLoaded():int{
             
             return 0;

--- a/src/com/videojs/providers/IProvider.as
+++ b/src/com/videojs/providers/IProvider.as
@@ -71,6 +71,16 @@ package com.videojs.providers{
         function get bufferedBytesEnd():int;
         
         /**
+         * Should return a value that indicates current buffer time before playing the stream, in seconds.
+         */
+        function get bufferTime():Number;
+        
+        /**
+         * See above.
+         */
+        function set bufferTime(pBufferTime:Number):void;
+        
+        /**
          * Should return the number of bytes that have been loaded thus far, or 0 if
          * this value is unknown or unable to be calculated (due to streaming, bitrate switching, etc)
          */

--- a/src/com/videojs/test/VideoJSModelTest.as
+++ b/src/com/videojs/test/VideoJSModelTest.as
@@ -30,5 +30,18 @@ package com.videojs.test
 			VideoJSModel.getInstance().volume = 0.5;
 			Assert.assertEquals(0.5, VideoJSModel.getInstance().volume);
 		}
+
+		[Test]
+		public function test_bufferTime():void
+		{
+			VideoJSModel.getInstance().bufferTime = -1;
+			Assert.assertEquals(0, VideoJSModel.getInstance().bufferTime);
+
+			VideoJSModel.getInstance().bufferTime = 2;
+			Assert.assertEquals(2, VideoJSModel.getInstance().bufferTime);
+
+			VideoJSModel.getInstance().bufferTime = 0.5;
+			Assert.assertEquals(0.5, VideoJSModel.getInstance().bufferTime);
+		}
 	}
 }


### PR DESCRIPTION
The video-js-swf doesn't have the interface to get/set Netstream.bufferTime and have set bufferTime=1(second) internally. It's almost working if network bandwidth is enough for streaming. However, handling the bufferTime is useful for narrow bandwidth.

Adobe documents describes how to handle the bufferTime dynamically.
http://help.adobe.com/en_US/flashmediaserver/devguide/WS5b3ccc516d4fbf351e63e3d11a0773d56e-7feaDev.html#WS82FD33FA-43D8-4f7a-BEAE-E3950CB694A1Dev
