### PR TITLE
Don't null out the throughput timer, just reset it

### DIFF
--- a/src/com/videojs/providers/HTTPVideoProvider.as
+++ b/src/com/videojs/providers/HTTPVideoProvider.as
@@ -406,12 +406,7 @@ package com.videojs.providers{
 
             if(_throughputTimer)
             {
-                try {
-                    _throughputTimer.stop();
-                    _throughputTimer = null;
-                } catch( err: Error ) {
-
-                }
+                _throughputTimer.reset();
             }
         }
         


### PR DESCRIPTION
It's not necessary to null out the throughput timer and it could be dereferenced if the src is changed while a seek is still "in-flight". Resetting it ensures it is stopped and zeroed and it can be garbage collected along with the rest of the HTTPVideoProvider. This was causing errors in videojs-contrib-hls when the source was changed quickly after a seek was requested.
