### PR TITLE
Fix for #136. Default paused to true.

### DIFF
--- a/src/com/videojs/VideoJSModel.as
+++ b/src/com/videojs/VideoJSModel.as
@@ -410,7 +410,7 @@ package com.videojs{
             if(_provider){
                 return _provider.paused;
             }
-            return false;
+            return true;
         }
 
         /**


### PR DESCRIPTION
Matches the spec for html5:
```
The paused attribute represents whether the media element is paused or not. The attribute must initially be true.
```