### PR TITLE
Live streams now return -1 for duration instead of 0

### DIFF
--- a/src/com/videojs/providers/HTTPVideoProvider.as
+++ b/src/com/videojs/providers/HTTPVideoProvider.as
@@ -99,9 +99,9 @@ package com.videojs.providers{
         }
         
         public function get duration():Number{
-			if (_isLive) {
-				return -1;
-			}
+            if (_isLive) {
+                return -1;
+            }
             else if(_metadata != null && _metadata.duration != undefined){
                 return Number(_metadata.duration);
             } else if( _durationOverride && _durationOverride > 0 ) {

--- a/src/com/videojs/providers/HTTPVideoProvider.as
+++ b/src/com/videojs/providers/HTTPVideoProvider.as
@@ -99,7 +99,10 @@ package com.videojs.providers{
         }
         
         public function get duration():Number{
-            if(_metadata != null && _metadata.duration != undefined){
+			if (_isLive) {
+				return -1;
+			}
+            else if(_metadata != null && _metadata.duration != undefined){
                 return Number(_metadata.duration);
             } else if( _durationOverride && _durationOverride > 0 ) {
                 return _durationOverride;

--- a/src/com/videojs/providers/RTMPVideoProvider.as
+++ b/src/com/videojs/providers/RTMPVideoProvider.as
@@ -77,7 +77,10 @@ package com.videojs.providers{
         }
         
         public function get duration():Number{
-            if(_metadata != null && _metadata.duration != undefined){
+            if (_isLive) {
+				return -1;
+			}
+			else if(_metadata != null && _metadata.duration != undefined){
                 return Number(_metadata.duration);
             }
             else{

--- a/src/com/videojs/providers/RTMPVideoProvider.as
+++ b/src/com/videojs/providers/RTMPVideoProvider.as
@@ -78,9 +78,9 @@ package com.videojs.providers{
         
         public function get duration():Number{
             if (_isLive) {
-				return -1;
-			}
-			else if(_metadata != null && _metadata.duration != undefined){
+                return -1;
+            }
+            else if(_metadata != null && _metadata.duration != undefined){
                 return Number(_metadata.duration);
             }
             else{


### PR DESCRIPTION
This is currently untested as I can't get the grunt build script to work at the moment.
