### PR TITLE
Return an empty time range while performing a seek in data generation mode

### DIFF
--- a/src/com/videojs/providers/HTTPVideoProvider.as
+++ b/src/com/videojs/providers/HTTPVideoProvider.as
@@ -209,6 +209,9 @@ package com.videojs.providers{
             if(_ns) {
                 if (_src.path === null) {
                     // data generation mode
+                    if (_isSeeking) {
+                        return [];
+                    }
                     return [[
                         _startOffset + _ns.time - _ns.backBufferLength,
                         _startOffset + _ns.time + _ns.bufferLength


### PR DESCRIPTION
This is to fix an issue where the Flash plugin isn't acting quite like MSE in data generation mode and it was always returning a buffer that has start and end points exactly equal to the seeking position.