### PR TITLE
Set _isSeeking in seekBySeconds even when _hasEnded is set

### DIFF
--- a/src/com/videojs/providers/HTTPVideoProvider.as
+++ b/src/com/videojs/providers/HTTPVideoProvider.as
@@ -356,6 +356,7 @@ package com.videojs.providers{
             }
             else if(_hasEnded)
             {
+                _isSeeking = true;
                 _playbackStarted = true;
                 _hasEnded = false;
             }


### PR DESCRIPTION
We were in a situation where if `endOfStream` was called (setting `_hasEnded` to true) and then we tried to replay by seeking to time 0, we wouldn't notify the player that seek had ended and the spinner would continue to show and playback would be broken until it timed out.