### PR TITLE
add startpram 4 pseudo streaming

### DIFF
--- a/src/VideoJS.as
+++ b/src/VideoJS.as
@@ -143,6 +143,10 @@ package{
               if(loaderInfo.parameters.rtmpStream != undefined && loaderInfo.parameters.rtmpStream != ""){
                 _app.model.rtmpStream = loaderInfo.parameters.rtmpStream;
               }
+
+              if(loaderInfo.parameters.startparam != undefined && loaderInfo.parameters.startparam != ""){
+                _app.model.startparam = loaderInfo.parameters.startparam;
+              }
             }
 
             // Hard coding this in for now until we can come up with a better solution for 5.0 to avoid XSS.
@@ -290,6 +294,9 @@ package{
                 case "rtmpStream":
                     return _app.model.rtmpStream;
                     break;
+                case "startparam":
+                    return _app.model.startparam;
+                    break;
             }
             return null;
         }
@@ -345,6 +352,9 @@ package{
                     break;
                 case "rtmpStream":
                     _app.model.rtmpStream = String(pValue);
+                    break;
+                case "startparam":
+                    _app.model.startparam = String(pValue);
                     break;
                 default:
                     _app.model.broadcastErrorEventExternally(ExternalErrorEventName.PROPERTY_NOT_FOUND, pPropertyName);

--- a/src/com/videojs/VideoJSModel.as
+++ b/src/com/videojs/VideoJSModel.as
@@ -42,6 +42,7 @@ package com.videojs{
         private var _src:String = "";
         private var _rtmpConnectionURL:String = "";
         private var _rtmpStream:String = "";
+        private var _startparam:String = "";
 
         private static var _instance:VideoJSModel;
 
@@ -244,6 +245,13 @@ package com.videojs{
             if(_autoplay){
                 play();
             }
+        }
+
+        public function get startparam():String {
+            return _startparam;
+        }
+        public function set startparam(pValue:String):void {
+            _startparam = pValue;
         }
 
         /**

--- a/src/com/videojs/providers/HTTPVideoProvider.as
+++ b/src/com/videojs/providers/HTTPVideoProvider.as
@@ -222,7 +222,7 @@ package com.videojs.providers{
                     // instance) but NetStream.bufferLength does not seem
                     // to return the full amount of buffered time for
                     // progressive download videos.
-                    return [[0, (_ns.bytesLoaded / _ns.bytesTotal) * duration]];
+                    return [[0, _startOffset + (_ns.bytesLoaded / _ns.bytesTotal) * (_metadata.duration - _startOffset)]];
                 }
             }
             return [];
@@ -368,8 +368,18 @@ package com.videojs.providers{
                 _startOffset = pTime;
                 return;
             }
-
-            _ns.seek(pTime);
+            var startBuffer = _startOffset + _ns.time;
+            var endBuffer = _startOffset + (_ns.bytesLoaded / _ns.bytesTotal) * (_metadata.duration - _startOffset);
+            if (_model.startparam !== "" && !(pTime > startBuffer && pTime < endBuffer)){
+                if (_src.path.indexOf('?') > -1) {
+                    _ns.play(_src.path + '&' + _model.startparam + '=' + pTime);
+                } else {
+                    _ns.play(_src.path + '?' + _model.startparam + '=' + pTime);
+                }
+                _startOffset = pTime;
+            } else {
+                _ns.seek(pTime);
+            }
 
         }
 
@@ -381,12 +391,35 @@ package com.videojs.providers{
                 }
                 else if(pPercent > 1){
                     _throughputTimer.stop();
-                    _ns.seek((pPercent / 100) * _metadata.duration);
+                    var startBuffer = _startOffset + _ns.time - _ns.backBufferLength;
+                    var endBuffer = _startOffset + _ns.time + _ns.bufferLength;
+                    var pTime = (pPercent / 100) * _metadata.duration;
+                    if (_model.startparam !== "" && !(pTime > startBuffer && pTime < endBuffer)){
+                        if (_src.path.indexOf('?') > -1) {
+                            _ns.play(_src.path + '&' + _model.startparam + '=' + pTime);
+                        } else {
+                            _ns.play(_src.path + '?' + _model.startparam + '=' + pTime);
+                        }
+                        _startOffset = pTime;
+                    } else {
+                        _ns.seek(pTime);
+                    }
                 }
                 else{
                     _throughputTimer.stop();
-                    _ns.seek(pPercent * _metadata.duration);
-
+                    var startBuffer = _startOffset + _ns.time - _ns.backBufferLength;
+                    var endBuffer = _startOffset + _ns.time + _ns.bufferLength;
+                    var pTime = pPercent * _metadata.duration;
+                    if (_model.startparam !== "" && !(pTime > startBuffer && pTime < endBuffer)){
+                        if (_src.path.indexOf('?') > -1) {
+                            _ns.play(_src.path + '&' + _model.startparam + '=' + pTime);
+                        } else {
+                            _ns.play(_src.path + '?' + _model.startparam + '=' + pTime);
+                        }
+                        _startOffset = pTime;
+                    } else {
+                        _ns.seek(pTime);
+                    }
                 }
             }
         }
@@ -659,6 +692,9 @@ package com.videojs.providers{
             if(pMetaData.duration != undefined){
                 _isLive = false;
                 _canSeekAhead = true;
+                if (_model.startparam !== "" && _startOffset !== 0){
+                    _metadata.duration += _startOffset;
+                }
                 _model.broadcastEventExternally(ExternalEventName.ON_DURATION_CHANGE, _metadata.duration);
             }
             else{


### PR DESCRIPTION
when used mp4 video and set first techOrder flash and seek forwards or change the quality by videojs-resolution-switcher, video-js-swf get all before media. I think best solution is Pseudostreaming.
