### PR TITLE
Player when scrubbing after video ends

### DIFF
--- a/src/com/videojs/providers/RTMPVideoProvider.as
+++ b/src/com/videojs/providers/RTMPVideoProvider.as
@@ -302,6 +302,7 @@ package com.videojs.providers{
             }
             else if(_hasEnded){
                 _ns.seek(pTime);
+                _isPaused = false;
                 _isPlaying = true;
                 _hasEnded = false;
                 _reportEnded = false;
@@ -604,11 +605,14 @@ package com.videojs.providers{
             _model.broadcastEventExternally(ExternalEventName.ON_METADATA, _metadata);
         }
 
+<<<<<<< 8e55ad1eac05dcb6bf8e93d5e8a759f7411a1958
         public function onTextData(pTextData:Object):void {
             _model.broadcastEvent(new VideoPlaybackEvent(VideoPlaybackEvent.ON_TEXT_DATA, {textData:pTextData}));
             _model.broadcastEventExternally(ExternalEventName.ON_TEXT_DATA, pTextData);
         }
 
+=======
+>>>>>>> fixed issue where 'pause' state was incorrect after video ends but the user scrubs back
         public function onCuePoint(pInfo:Object):void{
             _model.broadcastEvent(new VideoPlaybackEvent(VideoPlaybackEvent.ON_CUE_POINT, {cuepoint:pInfo}));
         }


### PR DESCRIPTION
After the video ends, if the user scrubs back without replaying the entire video the `pause` state was never correctly set and required the user to hit the `pause` button twice to get the JS and ActionScript back in sync.

This addresses and should fix the issue here: https://github.com/videojs/video-js-swf/issues/199
