### PR TITLE
Set seeking flag even if we haven't started playback

### DIFF
--- a/src/com/videojs/providers/HTTPVideoProvider.as
+++ b/src/com/videojs/providers/HTTPVideoProvider.as
@@ -365,6 +365,7 @@ package com.videojs.providers{
 
             if(_src.path === null)
             {
+                _isSeeking = true;
                 _startOffset = pTime;
                 return;
             }


### PR DESCRIPTION
If we are in data generation mode and even if `_playbackStarted` hasn't happened yet, we should still set `_isSeeking` to true so that we can correctly emit `seeked` after an initial (before playback) seek (such as on setupFirstPlay in contrib-hls).