### PR TITLE
Add rtmp bufferTime option

### DIFF
--- a/src/VideoJS.as
+++ b/src/VideoJS.as
@@ -147,7 +147,9 @@ package{
               if(loaderInfo.parameters.rtmpConnection != undefined && loaderInfo.parameters.rtmpConnection != ""){
                 _app.model.rtmpConnectionURL = loaderInfo.parameters.rtmpConnection;
               }
-
+              if(loaderInfo.parameters.rtmpBufferTime != undefined){
+                _app.model.rtmpBufferTime = loaderInfo.parameters.rtmpBufferTime;
+              }
               if(loaderInfo.parameters.rtmpStream != undefined && loaderInfo.parameters.rtmpStream != ""){
                 _app.model.rtmpStream = loaderInfo.parameters.rtmpStream;
               }
@@ -353,6 +355,9 @@ package{
                     break;
                 case "rtmpStream":
                     _app.model.rtmpStream = String(pValue);
+                    break;
+                case "rtmpBufferTime":
+                    _app.model.rtmpBufferTime = Number(pValue);
                     break;
                 default:
                     _app.model.broadcastErrorEventExternally(ExternalErrorEventName.PROPERTY_NOT_FOUND, pPropertyName);

--- a/src/com/videojs/VideoJSModel.as
+++ b/src/com/videojs/VideoJSModel.as
@@ -42,6 +42,7 @@ package com.videojs{
         private var _src:String = "";
         private var _rtmpConnectionURL:String = "";
         private var _rtmpStream:String = "";
+        private var _rtmpBufferTime:Number = 1;
 
         private static var _instance:VideoJSModel;
 
@@ -232,7 +233,8 @@ package com.videojs{
             if (_provider != null && _currentPlaybackType == PlaybackType.RTMP) {
                 var __src:Object = {
                     connectionURL: _rtmpConnectionURL,
-                    streamURL: _rtmpStream
+                    streamURL: _rtmpStream,
+                    bufferTime: _rtmpBufferTime
                 };
                 _provider.src = __src;
             }
@@ -244,6 +246,9 @@ package com.videojs{
             if(_autoplay){
                 play();
             }
+        }
+        public function set rtmpBufferTime(pBufferTime:Number):void {
+            _rtmpBufferTime = pBufferTime;
         }
 
         /**
@@ -598,7 +603,8 @@ package com.videojs{
                     else if(_currentPlaybackType == PlaybackType.RTMP){
                         __src = {
                             connectionURL: _rtmpConnectionURL,
-                            streamURL: _rtmpStream
+                            streamURL: _rtmpStream,
+                            bufferTime: _rtmpBufferTime
                         };
                         _provider = new RTMPVideoProvider();
                         _provider.attachVideo(_videoReference);

--- a/src/com/videojs/providers/RTMPVideoProvider.as
+++ b/src/com/videojs/providers/RTMPVideoProvider.as
@@ -422,7 +422,7 @@ package com.videojs.providers{
             _ns = new NetStream(_nc);
             _ns.addEventListener(NetStatusEvent.NET_STATUS, onNetStreamStatus);
             _ns.client = this;
-            _ns.bufferTime = 1;
+            _ns.bufferTime = _src.bufferTime;
             _ns.play(_src.streamURL);
             _videoReference.attachNetStream(_ns);
             _model.broadcastEventExternally(ExternalEventName.ON_LOAD_START);


### PR DESCRIPTION
When streaming rtmp, the NetStream bufferTime is hardcoded to 1.
It may be useful to let the user the ability to configure this in order to reduce latency or improve stream stability. Actually, without this option it's impossible to use video-js for low-latency rtmp streaming (see https://github.com/videojs/video.js/issues/2194).

This PR passes the `bufferTime` option in the rtmp `src` object. Not sure it's the best way to do it but I didn't want to add a setter for bufferTime to the `IProvider` interface since I'm not sure it's relevant for other providers.

To use it with videojs, simpy add the `rtmpBufferTime` option to `flashVars`, like this:

``` javascript
const player = videojs('my-video', {
    flash: {
        flashVars: {
            rtmpBufferTime: 0
        }
    }
});
```

The default value is 1 so it doesn't bring any breaking-change, it's an opt-in option.

Feel free to suggest any better way to add this feature, I'll update the PR !
