### PR TITLE
fix RTMP buffered()

### DIFF
--- a/src/com/videojs/providers/RTMPVideoProvider.as
+++ b/src/com/videojs/providers/RTMPVideoProvider.as
@@ -151,8 +151,8 @@ package com.videojs.providers{
         }
 
         public function get buffered():Array{
-            if(duration > 0){
-                return [[0, duration]];
+            if(_metadata != null && _metadata.duration != undefined && _metadata.duration > 0){
+                return [[0, _metadata.duration]];
             }
             else{
                 return [];


### PR DESCRIPTION
`duration` was never a thing. Try to get it from `_metadata` if available and greater than 0.

Fixes https://github.com/videojs/video.js/issues/4232