### PR TITLE
Decouple muted and vol=0 to allow muting/unmuting the player correctly

### DIFF
--- a/src/com/videojs/VideoJSModel.as
+++ b/src/com/videojs/VideoJSModel.as
@@ -26,6 +26,7 @@ package com.videojs{
         private var _currentPlaybackType:String;
         private var _videoReference:Video;
         private var _lastSetVolume:Number = 1;
+        private var _muted:Boolean = false;
         private var _provider:IProvider;
 
         // accessible properties
@@ -285,15 +286,17 @@ package com.videojs{
         }
 
         public function get muted():Boolean{
-            return (_volume == 0);
+            return _muted;
         }
         public function set muted(pValue:Boolean):void {
             if(pValue){
                 var __lastSetVolume:Number = _lastSetVolume;
+                _muted = true;
                 volume = 0;
                 _lastSetVolume = __lastSetVolume;
             }
             else{
+                _muted = false;
                 volume = _lastSetVolume;
             }
         }


### PR DESCRIPTION
Submitting as a possible means to address https://github.com/videojs/video-js-swf/issues/226 where muted() is dependent on volume level.

This change adds a _muted property and gets/sets it based on the value passed in.  If true, it still sets volume to 0 when muting but also sets _lastVolume so we can restore correctly. Also sets volume back to _lastVolume when un-muting.

Tested on Chrome 58.0.3029.110