### PR TITLE
Fix: Update broken mp4 test urls to working mp4 urls

### DIFF
--- a/sandbox/videojs.html.example
+++ b/sandbox/videojs.html.example
@@ -17,9 +17,9 @@
 <body>
 
 <video id="example_video_1" class="video-js vjs-default-skin" controls preload="none" width="640" height="264"
-       poster="http://video-js.zencoder.com/oceans-clip.png"
+       poster="http://vjs.zencdn.net/v/oceans.png"
        data-setup='{"techOrder": ["flash"]}'>
-    <source src="http://video-js.zencoder.com/oceans-clip.mp4" type='video/mp4' />
+    <source src="http://vjs.zencdn.net/v/oceans.mp4" type='video/mp4' />
 </video>
 
 </body>

--- a/tests/index.html
+++ b/tests/index.html
@@ -5,13 +5,13 @@
     <meta http-equiv="Content-Style-Type" content="text/css" />
     <meta http-equiv="imagetoolbar" content="no" />
     <title>VideoJS Workbench</title>
-    <link rel="stylesheet" href="css/reset.css"/> 
-    <link rel="stylesheet" href="css/styles.css"/> 
+    <link rel="stylesheet" href="css/reset.css"/>
+    <link rel="stylesheet" href="css/styles.css"/>
     <script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/1.6.2/jquery.min.js"></script>
     <script type="text/javascript" src="js/swfobject.js"></script>
     <script type="text/javascript">
 
-      
+
       function init(){
 
         // control
@@ -85,7 +85,7 @@
           $propVideoHeight = $("#propVideoHeight");
 
       }
-      
+
       function log(msg){
         try{
           console.log(msg);
@@ -97,7 +97,7 @@
         createSWF(e);
         setTimeout(waitForSWF, 100);
       }
-      
+
       function waitForSWF() {
         var vid = $("#videoPlayer")[0];
         log("Waiting for the SWF to be loaded...");
@@ -129,12 +129,12 @@
           allowScriptAccess: "always",
           bgcolor: "#000000"
         };
-      
+
         var attributes = {
           id: "videoPlayer",
           name: "videoPlayer"
         };
-      
+
         swfobject.embedSWF("../dist/video-js.swf", "videoPlayer", "100%", "100%", "10.3", "", flashvars, params, attributes);
 
       }
@@ -159,7 +159,7 @@
           e.preventDefault();
         }
         var el = $("#videoPlayer")[0];
-        el.vjs_src("http://video-js.zencoder.com/oceans-clip.mp4?");
+        el.vjs_src("http://vjs.zencdn.net/v/oceans.mp4?");
       }
 
       function playVideo(e){
@@ -220,7 +220,7 @@
       function updatePlayerProperties(){
 
         var el = $("#videoPlayer")[0];
-        
+
         $propCurrentSrc.html(el.vjs_getProperty("currentSrc"));
         $propCurrentTime.html(el.vjs_getProperty("currentTime"));
         $propTime.html(el.vjs_getProperty("time"));
@@ -349,15 +349,15 @@
           <div id="videoPlayerWrapper" style="">
             <div id="videoPlayer"></div>
           </div>
-        </div> 
+        </div>
         <div id="control" class="span2">
           <h1>Simple Controls</h1>
           <p>Once playback has started, the SWF's control methods will work:</p>
           <a id="btnPause" class="button" href="#">pause()</a><br>
-          <a id="btnResume" class="button" href="#">resume()</a><br> 
-          <a id="btnSeek5" class="button" href="#">seek(5)</a><br> 
+          <a id="btnResume" class="button" href="#">resume()</a><br>
+          <a id="btnSeek5" class="button" href="#">seek(5)</a><br>
         </div>
       </div>
     </section>
-  </body>  
+  </body>
 </html>

--- a/tests/manual/manual.html
+++ b/tests/manual/manual.html
@@ -5,13 +5,13 @@
     <meta http-equiv="Content-Style-Type" content="text/css" />
     <meta http-equiv="imagetoolbar" content="no" />
     <title>VideoJS Workbench</title>
-    <link rel="stylesheet" href="css/reset.css"/> 
-    <link rel="stylesheet" href="css/styles.css"/> 
+    <link rel="stylesheet" href="css/reset.css"/>
+    <link rel="stylesheet" href="css/styles.css"/>
     <script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/1.6.2/jquery.min.js"></script>
     <script type="text/javascript" src="js/swfobject.js"></script>
     <script type="text/javascript">
 
-      
+
       function init(){
 
         // control
@@ -85,7 +85,7 @@
           $propVideoHeight = $("#propVideoHeight");
 
       }
-      
+
       function log(msg){
         try{
           console.log(msg);
@@ -97,7 +97,7 @@
         createSWF(e);
         setTimeout(waitForSWF, 100);
       }
-      
+
       function waitForSWF() {
         var vid = $("#videoPlayer")[0];
         log("Waiting for the SWF to be loaded...");
@@ -129,12 +129,12 @@
           allowScriptAccess: "always",
           bgcolor: "#000000"
         };
-      
+
         var attributes = {
           id: "videoPlayer",
           name: "videoPlayer"
         };
-      
+
         swfobject.embedSWF("../../dist/video-js.swf", "videoPlayer", "100%", "100%", "10.3", "", flashvars, params, attributes);
 
       }
@@ -159,7 +159,7 @@
           e.preventDefault();
         }
         var el = $("#videoPlayer")[0];
-        el.vjs_src("http://video-js.zencoder.com/oceans-clip.mp4?");
+        el.vjs_src("http://vjs.zencdn.net/v/oceans.mp4?");
       }
 
       function playVideo(e){
@@ -220,7 +220,7 @@
       function updatePlayerProperties(){
 
         var el = $("#videoPlayer")[0];
-        
+
         $propCurrentSrc.html(el.vjs_getProperty("currentSrc"));
         $propCurrentTime.html(el.vjs_getProperty("currentTime"));
         $propTime.html(el.vjs_getProperty("time"));
@@ -355,15 +355,15 @@
           <div id="videoPlayerWrapper" style="">
             <div id="videoPlayer"></div>
           </div>
-        </div> 
+        </div>
         <div id="control" class="span2">
           <h1>Simple Controls</h1>
           <p>Once playback has started, the SWF's control methods will work:</p>
           <a id="btnPause" class="button" href="#">pause()</a><br>
-          <a id="btnResume" class="button" href="#">resume()</a><br> 
-          <a id="btnSeek5" class="button" href="#">seek(5)</a><br> 
+          <a id="btnResume" class="button" href="#">resume()</a><br>
+          <a id="btnSeek5" class="button" href="#">seek(5)</a><br>
         </div>
       </div>
     </section>
-  </body>  
+  </body>
 </html>

--- a/tests/manual/manual_full.html
+++ b/tests/manual/manual_full.html
@@ -5,15 +5,15 @@
     <meta http-equiv="Content-Style-Type" content="text/css" />
     <meta http-equiv="imagetoolbar" content="no" />
     <title>VideoJS Workbench</title>
-    <link rel="stylesheet" href="css/reset.css"/> 
-    <link rel="stylesheet" href="css/styles.css"/> 
+    <link rel="stylesheet" href="css/reset.css"/>
+    <link rel="stylesheet" href="css/styles.css"/>
     <script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/1.6.2/jquery.min.js"></script>
     <script type="text/javascript" src="js/swfobject.js"></script>
     <script type="text/javascript">
 
-      
+
       function init(){
-        
+
         $("#btnInstantiate").click(createSWF);
         $("#btnSetProps").click(setProperties);
         $("#btnSetSrc").click(setSource);
@@ -103,7 +103,7 @@
           $propVideoHeight = $("#propVideoHeight");
 
       }
-      
+
       function log(msg){
         try{
           console.log(msg);
@@ -128,12 +128,12 @@
           allowScriptAccess: "always",
           bgcolor: "#000000"
         };
-      
+
         var attributes = {
           id: "videoPlayer",
           name: "videoPlayer"
         };
-      
+
         swfobject.embedSWF("../../dist/video-js.swf", "videoPlayer", "100%", "100%", "10.3", "", flashvars, params, attributes);
 
       }
@@ -168,7 +168,7 @@
       function setSource(e){
         e.preventDefault();
         var el = $("#videoPlayer")[0];
-        el.vjs_src("http://video-js.zencoder.com/oceans-clip.mp4?");
+        el.vjs_src("http://vjs.zencdn.net/v/oceans.mp4?");
       }
 
       function loadVideo(e){
@@ -233,7 +233,7 @@
       function updatePlayerProperties(){
 
         var el = $("#videoPlayer")[0];
-        
+
         $propCurrentSrc.html(el.vjs_getProperty("currentSrc"));
         $propCurrentTime.html(el.vjs_getProperty("currentTime"));
         $propTime.html(el.vjs_getProperty("time"));
@@ -360,7 +360,7 @@
               </div>
             </div>
     </section>
-    
+
     <section id="instantiation">
       <div class="row">
         <div class="span2">
@@ -373,7 +373,7 @@
           <div id="videoPlayerWrapper" style="">
             <div id="videoPlayer"></div>
           </div>
-        </div> 
+        </div>
       </div>
     </section>
 
@@ -390,7 +390,7 @@
           </ul>
           <a id="btnSetProps" class="button" href="#">Set Properties</a>
           <p>Next, we'll call src() to let the swf know where the media asset can be found:</p>
-          <a id="btnSetSrc" class="button" href="#">src("http://video-js.zencoder.com/oceans-clip.mp4?")</a>
+          <a id="btnSetSrc" class="button" href="#">src("http://vjs.zencdn.net/v/oceans.mp4?")</a>
           <p>If the SWF's autoplay property had been set to true at any point prior to this src() call, loading and playback would begin.</p>
           <p>To begin loading without playing, call load():</p>
           <a id="btnLoad" class="button" href="#">load()</a>
@@ -400,14 +400,14 @@
         <div id="control" class="span3">
           <h1>Step 3: Control</h1>
           <p>Once playback has started, the SWF's control methods will work:</p>
-          <a id="btnPause" class="button" href="#">pause()</a> 
-          <a id="btnResume" class="button" href="#">resume()</a> 
+          <a id="btnPause" class="button" href="#">pause()</a>
+          <a id="btnResume" class="button" href="#">resume()</a>
           <br />
-          <a id="btnSeek5" class="button" href="#">seek(5)</a> 
-          <a id="btnSeek10" class="button" href="#">seek(10)</a> 
+          <a id="btnSeek5" class="button" href="#">seek(5)</a>
+          <a id="btnSeek10" class="button" href="#">seek(10)</a>
           <a id="btnSeek15" class="button" href="#">seek(15)</a>
           <br />
-          <a id="btnEnlarge" class="button" href="#">enlarge</a> 
+          <a id="btnEnlarge" class="button" href="#">enlarge</a>
           <a id="btnReduce" class="button" href="#">reduce</a>
         </div>
       </div>
@@ -415,5 +415,5 @@
 
 
 
-  </body>  
+  </body>
 </html>

--- a/tests/test.js
+++ b/tests/test.js
@@ -6,10 +6,10 @@ function createSWF(e){
     readyFunction: "onSWFReady",
     eventProxyFunction: "onSWFEvent",
     errorEventProxyFunction: "onSWFErrorEvent",
-    src: "http://video-js.zencoder.com/oceans-clip.mp4",
+    src: "http://vjs.zencdn.net/v/oceans.mp4",
     autoplay: false,
     preload: 'auto',
-    poster: "http://video-js.zencoder.com/oceans-clip.png"
+    poster: "http://vjs.zencdn.net/v/oceans.png"
   };
 
   var params = {
@@ -34,7 +34,7 @@ function swfSetup(){
     this.swf = document.getElementById(swfID);
     start();
   }, this);
-  
+
   window.onSWFEvent = function(swfID, eventName){
     console.log("onSWFEvent", swfID, eventName);
 
@@ -141,224 +141,224 @@ test("Play", 1, function() {
 //   setup: playerSetup,
 //   teardown: playerTeardown
 // });
-// 
+//
 // function failOnEnded() {
 //   this.player.one("ended", _V_.proxy(this, function(){
 //     start();
 //   }));
 // }
-// 
+//
 // // Play Method
 // test("play()", 1, function() {
 //   stop();
-// 
+//
 //   this.player.one("playing", _V_.proxy(this, function(){
 //     ok(true);
 //     start();
 //   }));
-// 
+//
 //   this.player.play();
-// 
+//
 //   failOnEnded.call(this);
 // });
-// 
+//
 // // Pause Method
 // test("pause()", 1, function() {
 //   stop();
-// 
+//
 //   // Flash doesn't currently like calling pause immediately after 'playing'.
 //   this.player.one("timeupdate", _V_.proxy(this, function(){
-// 
+//
 //     this.player.pause();
-// 
+//
 //   }));
-// 
+//
 //   this.player.addEvent("pause", _V_.proxy(this, function(){
 //     ok(true);
 //     start();
 //   }));
-// 
+//
 //   this.player.play();
 // });
-// 
+//
 // // Paused Method
 // test("paused()", 2, function() {
 //   stop();
-// 
+//
 //   this.player.one("timeupdate", _V_.proxy(this, function(){
 //     equal(this.player.paused(), false);
 //     this.player.pause();
 //   }));
-// 
+//
 //   this.player.addEvent("pause", _V_.proxy(this, function(){
 //     equal(this.player.paused(), true);
 //     start();
 //   }));
-// 
+//
 //   this.player.play();
 // });
-// 
+//
 // test("currentTime()", 1, function() {
 //   stop();
-// 
+//
 //   // Try for 3 time updates, sometimes it updates at 0 seconds.
 //   // var tries = 0;
-// 
+//
 //   // Can't rely on just time update because it's faked for Flash.
 //   this.player.one("loadeddata", _V_.proxy(this, function(){
-// 
+//
 //     this.player.addEvent("timeupdate", _V_.proxy(this, function(){
-// 
+//
 //       if (this.player.currentTime() > 0) {
 //         ok(true, "Time is greater than 0.");
 //         start();
 //       } else {
 //         // tries++;
 //       }
-// 
+//
 //       // if (tries >= 3) {
 //       //   start();
 //       // }
 //     }));
-// 
+//
 //   }));
-//   
+//
 //   this.player.play();
 // });
-// 
-// 
+//
+//
 // test("currentTime(seconds)", 2, function() {
 //   stop();
-// 
+//
 //   // var afterPlayback = _V_.proxy(this, function(){
 //   //   this.player.currentTime(this.player.duration() / 2);
-//   // 
+//   //
 //   //   this.player.addEvent("timeupdate", _V_.proxy(this, function(){
 //   //     ok(this.player.currentTime() > 0, "Time is greater than 0.");
-//   //     
+//   //
 //   //     this.player.pause();
-//   //     
+//   //
 //   //     this.player.addEvent("timeupdate", _V_.proxy(this, function(){
 //   //       ok(this.player.currentTime() == 0, "Time is 0.");
 //   //       start();
 //   //     }));
-//   // 
+//   //
 //   //     this.player.currentTime(0);
 //   //   }));
 //   // });
-// 
+//
 //   // Wait for Source to be ready.
 //   this.player.one("loadeddata", _V_.proxy(this, function(){
-// 
+//
 //     _V_.log("loadeddata", this.player);
 //     this.player.currentTime(this.player.duration() - 1);
-// 
+//
 //   }));
-//   
+//
 //   this.player.one("seeked", _V_.proxy(this, function(){
-// 
+//
 //     _V_.log("seeked", this.player.currentTime())
 //     ok(this.player.currentTime() > 1, "Time is greater than 1.");
-// 
+//
 //     this.player.one("seeked", _V_.proxy(this, function(){
-//       
+//
 //       _V_.log("seeked2", this.player.currentTime())
-// 
+//
 //       ok(this.player.currentTime() <= 1, "Time is less than 1.");
 //       start();
-// 
+//
 //     }));
-// 
+//
 //     this.player.currentTime(0);
-// 
+//
 //   }));
-// 
-// 
+//
+//
 //   this.player.play();
-// 
+//
 //   // this.player.one("timeupdate", _V_.proxy(this, function(){
-//   // 
+//   //
 //   //   this.player.currentTime(this.player.duration() / 2);
-//   // 
+//   //
 //   //   this.player.one("timeupdate", _V_.proxy(this, function(){
 //   //     ok(this.player.currentTime() > 0, "Time is greater than 0.");
-//   // 
+//   //
 //   //     this.player.pause();
 //   //     this.player.currentTime(0);
-//   // 
+//   //
 //   //     this.player.one("timeupdate", _V_.proxy(this, function(){
-//   // 
+//   //
 //   //       ok(this.player.currentTime() == 0, "Time is 0.");
 //   //       start();
-//   // 
+//   //
 //   //     }));
-//   // 
+//   //
 //   //   }));
-//   // 
-//   // 
+//   //
+//   //
 //   // }));
-// 
+//
 // });
-// 
+//
 // /* Events
 // ================================================================================ */
 // module("API Events", {
 //   setup: playerSetup,
 //   teardown: playerTeardown
 // });
-// 
+//
 // var playEventList = []
-// 
+//
 // // Test all playback events
 // test("Initial Events", 11, function() {
 //   stop(); // Give 30 seconds to run then fail.
-// 
+//
 //   var events = [
 //     // "loadstart" // Called during setup
 //     "play",
 //     "playing",
-// 
+//
 //     "durationchange",
 //     "loadedmetadata",
 //     "loadeddata",
-// 
+//
 //     "progress",
 //     "timeupdate",
-// 
+//
 //     "canplay",
 //     "canplaythrough",
-// 
+//
 //     "pause",
 //     "ended"
 //   ];
-// 
+//
 //   // Add an event listener for each event type.
 //   for (var i=0, l=events.length; i<l; i++) {
 //     var evt = events[i];
-//     
+//
 //     // Bind player and event name to function so event name value doesn't get overwritten.
 //     this.player.one(evt, _V_.proxy({ player: this.player, evt: evt }, function(){
 //       ok(true, this.evt);
-// 
+//
 //       // Once we reach canplaythrough, pause the video and wait for 'paused'.
 //       if (this.evt == "canplaythrough") {
 //         this.player.pause();
-//       
+//
 //       // After we've paused, go to the end of the video and wait for 'ended'.
 //       } else if (this.evt == "pause") {
 //         this.player.currentTime(this.player.duration() - 1);
-// 
+//
 //         // Flash has an issue calling play too quickly after currentTime. Hopefully we'll fix this.
 //         setTimeout(this.player.proxy(function(){
 //           this.play();
 //         }), 250);
-// 
+//
 //       // When we reach ended, we're done. Continue with the test suite.
 //       } else if (this.evt == "ended") {
 //         start();
 //       }
 //     }));
 //   }
-// 
+//
 //   this.player.play();
 // });


### PR DESCRIPTION
The original links to the test mp4s are dead, and made it seem as though the project was not working when running tests.  This PR just updates those references so that they are to working assets.

The whitespace changes here are due to some windows based shenanigans from a previous PR (in my local diff I had references to ^M4s that were removed).  It's probably easier to read this with ?w=1.