### PR TITLE
#15 Adding Apache 2.0 License

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "description": "The Flash-fallback video player for video.js (http://videojs.com)",
   "version": "5.4.2",
   "copyright": "Copyright 2014 Brightcove, Inc. https://github.com/videojs/video-js-swf/blob/master/LICENSE",
+  "license": "Apache-2.0",
   "keywords": [
     "flash",
     "video",


### PR DESCRIPTION
Per videojs/video-js-swf#15 the license should be specified as Apache 2.0 